### PR TITLE
Added channel functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/02/13 13:48:05 by hmunoz-g          #+#    #+#              #
-#    Updated: 2025/03/18 17:26:29 by hmunoz-g         ###   ########.fr        #
+#    Updated: 2025/03/19 12:09:07 by hmunoz-g         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -46,7 +46,9 @@ SRC         := src/main.cpp \
 				src/objects/Channel.cpp \
 				src/commands/CommandManager.cpp \
 				src/commands/PopulationCommand.cpp \
-				src/commands/QuitCommand.cpp 
+				src/commands/ChannelListCommand.cpp \
+				src/commands/QuitCommand.cpp \
+				src/commands/JoinCommand.cpp 
 
 OBJS        = $(addprefix $(OBJ_DIR)/, $(SRC:.cpp=.o))
 DEPS        = $(addprefix $(DEP_DIR)/, $(SRC:.cpp=.d))

--- a/includes/ChannelManager.hpp
+++ b/includes/ChannelManager.hpp
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ChannelManager.hpp                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 10:29:13 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 11:29:06 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef CHANNELMANAGER_HPP
+# define CHANNELMANAGER_HPP
+
+# include <map>
+# include <vector>
+# include <string>
+# include <sstream> 
+# include "objects/Channel.hpp"
+# include <sys/types.h>
+# include <sys/socket.h>
+
+class ChannelManager {
+	private:
+    	std::map<std::string, Channel> _channels;
+
+	public:
+		// Constructor and Destructor
+		ChannelManager();
+		~ChannelManager();
+
+		// Getters and Setters
+		const std::map<std::string, Channel> &getChannelList() const;
+		Channel* getChannel(const std::string &name);
+
+		// Methods
+		
+		bool createChannel(const std::string &name);
+		bool removeChannel(const std::string &name);
+		void printChannelList(int client_fd);
+};
+
+#endif

--- a/includes/ServerManager.hpp
+++ b/includes/ServerManager.hpp
@@ -6,7 +6,7 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 17:07:50 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2025/03/18 14:44:26 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2025/03/19 11:16:32 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,8 @@
 
 # include "SocketManager.hpp"
 # include "ClientManager.hpp"
-#include "commands/CommandManager.hpp"
+# include "ChannelManager.hpp"
+# include "commands/CommandManager.hpp"
 
 class ServerManager {
 	private:
@@ -34,6 +35,7 @@ class ServerManager {
 		std::vector<struct pollfd> _fds;
 		SocketManager *_socketManager;
 		ClientManager *_clientManager;
+		ChannelManager *_channelManager;
 		CommandManager *_commandManager;
 
 		//Message macros

--- a/includes/commands/ChannelListCommand.hpp
+++ b/includes/commands/ChannelListCommand.hpp
@@ -1,35 +1,34 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   PopulationCommand.hpp                              :+:      :+:    :+:   */
+/*   ChannelListCommand.hpp                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/03/18 11:16:21 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2025/03/19 11:08:55 by hmunoz-g         ###   ########.fr       */
+/*   Created: 2025/03/19 11:06:27 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 11:14:42 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 //This is a TESTING command
 
-#ifndef POPULATIONCOMMAND_HPP
-# define POPULATIONCOMMAND_HPP
+#ifndef CHANNELLISTCOMMAND
+# define CHANNELLISTCOMMAND
 
 # include <string>
 # include <sys/socket.h>
 
-
 # include "ICommand.hpp"
 
-class ClientManager;
+class ChannelManager;
 
-class PopulationCommand : public ICommand {
-private:
-    ClientManager *_clientManager;
+class ChannelListCommand : public ICommand {
+	private:
+		ChannelManager *_channelManager;
 
-public:
-    PopulationCommand(ClientManager *clientManager);
-    void executeCommand(int client_fd, const ParsedMessage &parsedMsg);
+	public:
+		ChannelListCommand(ChannelManager *channelManager);
+		void executeCommand(int client_fd, const ParsedMessage &parsedMsg);
 };
 
 #endif

--- a/includes/commands/CommandManager.hpp
+++ b/includes/commands/CommandManager.hpp
@@ -6,7 +6,7 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/18 11:24:49 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2025/03/18 16:27:47 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2025/03/19 12:10:06 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,8 +25,11 @@
 
 # include "PopulationCommand.hpp"
 # include "QuitCommand.hpp"
+# include "JoinCommand.hpp"
+# include "ChannelListCommand.hpp"
 
 class ServerManager;
+class ChannelManager;
 
 class CommandManager {
 	private:
@@ -34,7 +37,7 @@ class CommandManager {
 
 	public:
 		// Constructor and Destructor
-		CommandManager(ClientManager* clientManager, ServerManager* serverManager);
+		CommandManager(ClientManager* clientManager, ChannelManager *channelmanager, ServerManager* serverManager);
 		~CommandManager();
 
 		// Methods

--- a/includes/commands/JoinCommand.hpp
+++ b/includes/commands/JoinCommand.hpp
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   JoinCommand.hpp                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 11:31:42 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 12:12:36 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef JOINCOMMAND_HPP
+# define JOINCOMMAND_HPP
+
+# include "ICommand.hpp"
+
+class ChannelManager;
+class ClientManager;
+
+class JoinCommand : public ICommand {
+	private:
+		ChannelManager *_channelManager;
+		ClientManager *_clientManager;
+
+		//Message macros
+		static const std::string CREATIONSCCS;
+		static const std::string JOINEDMEMBERSCCS;
+		static const std::string JOINEDOPERATORSCCS;
+		static const std::string CREATIONERR;
+		static const std::string JOINEDMEMBERERR;
+		static const std::string JOINEDOPERATORERR;
+
+	public:
+		//Constructors and Destructor
+		JoinCommand();
+		~JoinCommand();
+		JoinCommand(ChannelManager *channelManager, ClientManager *clientManager);
+
+		//Method
+		void executeCommand(int client_fd, const ParsedMessage &parsedMsg);
+};
+
+#endif

--- a/includes/objects/Channel.hpp
+++ b/includes/objects/Channel.hpp
@@ -1,0 +1,52 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Channel.hpp                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 10:07:49 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 10:56:24 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef CHANNEL_HPP
+# define CHANNEL_HPP
+
+# include <vector>
+# include <string>
+# include <map>
+# include <algorithm>
+# include "RegisteredClient.hpp"
+
+class Channel {
+	private:
+		std::string _name;
+		std::string _topic;
+		std::vector<RegisteredClient*> _members;
+		std::vector<RegisteredClient*> _operators;
+
+	public:
+		// Constructor and Destructor
+		Channel();
+		Channel(const std::string &name);
+		~Channel();
+
+		// Getters and Setters
+		const std::string &getName() const;
+		const std::string &getTopic() const;
+		const std::vector<RegisteredClient*> &getMembers() const;
+		const std::vector<RegisteredClient*> &getOperators() const;
+
+		void setTopic(const std::string &topic);
+		void setName(const std::string &name);
+
+		// Methods
+		bool addMember(RegisteredClient *client);
+		bool addOperator(RegisteredClient *oper);
+		bool RemoveMember(RegisteredClient *client);
+		bool RemoveOperator(RegisteredClient *oper);
+
+};
+
+#endif

--- a/src/ChannelManager.cpp
+++ b/src/ChannelManager.cpp
@@ -1,0 +1,92 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ChannelManager.cpp                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 10:28:43 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 11:29:03 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/ChannelManager.hpp"
+
+// Constructor and Destructor
+ChannelManager::ChannelManager() {}
+
+ChannelManager::~ChannelManager() {}
+
+// Getters and Setters
+const std::map<std::string, Channel> &ChannelManager::getChannelList() const { return (_channels); }
+
+Channel* ChannelManager::getChannel(const std::string &name) {
+	if (_channels.find(name) != _channels.end()) {
+		return &_channels[name];
+	}
+	return (NULL);
+}
+
+//Methods
+bool ChannelManager::createChannel(const std::string &name) {
+    if (_channels.find(name) != _channels.end()) {
+        return (false);
+    }
+
+    _channels[name] = Channel(name);
+    return (true);
+}
+
+bool ChannelManager::removeChannel(const std::string &name) {
+	if (_channels.find(name) == _channels.end()) {
+        return (false);
+    }
+	
+	_channels.erase(name);
+	return (true);
+}
+
+void ChannelManager::printChannelList(int client_fd){
+	if (_channels.empty()) {
+		std::string response = "No available channels.\n";
+		send(client_fd, response.c_str(), response.length(), 0);
+		return;
+	}
+
+	std::ostringstream response;
+	response << "Channels available:\n";
+
+	for (std::map<std::string, Channel>::const_iterator it = _channels.begin(); it != _channels.end(); ++it) {
+		const Channel& channel = it->second;
+		response << " - " << channel.getName() << " - " << channel.getTopic() << "\n";
+
+		// Operators
+		response << "    - Operators: ";
+		const std::vector<RegisteredClient*>& operators = channel.getOperators();
+		if (operators.empty()) {
+			response << "None";
+		} else {
+			for (size_t i = 0; i < operators.size(); i++) {
+				if (i > 0) response << ", ";
+				response << operators[i]->getNickname();
+			}
+		}
+		response << "\n";
+
+		// Members
+		response << "    - Members: ";
+		const std::vector<RegisteredClient*>& members = channel.getMembers();
+		if (members.empty()) {
+			response << "None";
+		} else {
+			for (size_t i = 0; i < members.size(); i++) {
+				if (i > 0) response << ", ";
+				response << members[i]->getNickname();
+			}
+		}
+		response << "\n";
+	}
+
+	std::string responseStr = response.str();
+	send(client_fd, responseStr.c_str(), responseStr.length(), 0);
+	}

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -6,7 +6,7 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 17:08:39 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2025/03/18 16:18:02 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2025/03/19 11:17:46 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,8 @@ const std::string ServerManager::RECONECTSCCS = "Welcome back to ft_irc";
 ServerManager::ServerManager(int port, const std::string &password) 
     : _socketManager(new SocketManager(port)), 
       _clientManager(new ClientManager(password)),
-      _commandManager(new CommandManager(_clientManager, this)) {
+      _channelManager(new ChannelManager()), 
+      _commandManager(new CommandManager(_clientManager, _channelManager, this)) {
 }
 
 ServerManager::~ServerManager() {

--- a/src/commands/ChannelListCommand.cpp
+++ b/src/commands/ChannelListCommand.cpp
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ChannelListCommand.cpp                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 11:09:10 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 11:21:38 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/commands/ChannelListCommand.hpp"
+#include "../../includes/ChannelManager.hpp"
+
+//Constructor
+ChannelListCommand::ChannelListCommand(ChannelManager *ChannelManager) : _channelManager(ChannelManager) {}
+
+//Method
+void ChannelListCommand::executeCommand(int client_fd, const ParsedMessage &parsedMsg) {
+	(void)parsedMsg;
+
+	std::string response = "Channels currently available:\n";
+	send(client_fd, response.c_str(), response.length(), 0);
+	_channelManager->printChannelList(client_fd);
+
+	std::cout << "ChannelList command executed by client " << client_fd << std::endl;
+}

--- a/src/commands/CommandManager.cpp
+++ b/src/commands/CommandManager.cpp
@@ -6,17 +6,20 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/18 11:24:23 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2025/03/18 16:19:11 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2025/03/19 12:10:08 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/commands/CommandManager.hpp"
+#include "../../includes/ChannelManager.hpp"
 
 // Constructor and Destructor
 
-CommandManager::CommandManager(ClientManager* clientManager, ServerManager* serverManager) {
+CommandManager::CommandManager(ClientManager *clientManager, ChannelManager *channelManager, ServerManager *serverManager) {
     _commands["POPULATION"] = new PopulationCommand(clientManager);
+	_commands["CHANNELLIST"] = new ChannelListCommand(channelManager);
     _commands["QUIT"] = new QuitCommand(serverManager);
+	_commands["JOIN"] = new JoinCommand(channelManager, clientManager);
 }
 
 CommandManager::~CommandManager() {

--- a/src/commands/JoinCommand.cpp
+++ b/src/commands/JoinCommand.cpp
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   JoinCommand.cpp                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 11:33:55 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 12:23:58 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/commands/JoinCommand.hpp"
+#include "../../includes/ChannelManager.hpp"
+#include "../../includes/ClientManager.hpp"
+
+// Message macros
+const std::string JoinCommand::CREATIONSCCS = "Channel created with name ";
+const std::string JoinCommand::JOINEDMEMBERSCCS = "Joined as member to channel ";
+const std::string JoinCommand::JOINEDOPERATORSCCS = "Joined as operator to channel ";
+const std::string JoinCommand::CREATIONERR = "Failed to create channel ";
+const std::string JoinCommand::JOINEDOPERATORERR = "Failed to join as operator to channel ";
+const std::string JoinCommand::JOINEDMEMBERERR = "Failed to join as member to channel ";
+
+// Constructors and destructor
+JoinCommand::JoinCommand() {}
+
+JoinCommand::JoinCommand(ChannelManager *channelManager, ClientManager *clientManager) : _channelManager(channelManager), _clientManager(clientManager) {}
+
+JoinCommand::~JoinCommand() {}
+
+//Methods
+void JoinCommand::executeCommand(int client_fd, const ParsedMessage &parsedMsg) {
+	std::string name = parsedMsg.params[0];
+	RegisteredClient *client = _clientManager->getClientFromFd(client_fd);
+
+	if (_channelManager->getChannelList().find(name) == _channelManager->getChannelList().end()) {
+		if (_channelManager->createChannel(name)) {
+			std::string creationGoodOutput = CREATIONSCCS + name + "\n";
+			send(client_fd, creationGoodOutput.c_str(), creationGoodOutput.length(), 0);
+		} else {
+			std::string creationBadOutput = CREATIONERR + name + "\n";
+			send(client_fd, creationBadOutput.c_str(), creationBadOutput.length(), 0);
+		}
+	}
+
+	Channel *channel = _channelManager->getChannel(name);
+	if (channel->getOperators().empty()) {
+		if (channel->addOperator(client)) {
+			std::string operatorGoodMessage = JOINEDOPERATORSCCS + name + "\n";
+			send(client_fd, operatorGoodMessage.c_str(), operatorGoodMessage.length(), 0);
+		} else {
+			std::string operatorBadMessage = JOINEDOPERATORERR + name + "\n";
+			send(client_fd, operatorBadMessage.c_str(), operatorBadMessage.length(), 0);
+		}
+	} else {
+		if (channel->addMember(client)) {
+			std::string memberGoodMessage = JOINEDMEMBERSCCS + name + "\n";
+			send(client_fd, memberGoodMessage.c_str(), memberGoodMessage.length(), 0);
+		} else {
+			std::string memberBadMessage = JOINEDMEMBERERR + name + "\n";
+			send(client_fd, memberBadMessage.c_str(), memberBadMessage.length(), 0);
+		}
+	}
+}

--- a/src/commands/PopulationCommand.cpp
+++ b/src/commands/PopulationCommand.cpp
@@ -6,23 +6,22 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/18 11:16:21 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2025/03/18 16:55:39 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2025/03/19 11:10:55 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/commands/PopulationCommand.hpp"
 #include "../../includes/ClientManager.hpp"
 
-// Constructor that takes a ClientManager reference
-PopulationCommand::PopulationCommand(ClientManager* clientManager) : _clientManager(clientManager) {}
+// Constructor
+PopulationCommand::PopulationCommand(ClientManager *clientManager) : _clientManager(clientManager) {}
 
-void PopulationCommand::executeCommand(int client_fd, const ParsedMessage& parsedMsg) {
-    (void)parsedMsg; // To avoid unused parameter warning
+void PopulationCommand::executeCommand(int client_fd, const ParsedMessage &parsedMsg) {
+    (void)parsedMsg;
     
     std::string response = "Server Population:\n";
     send(client_fd, response.c_str(), response.length(), 0);
     _clientManager->printClientList(client_fd);
     
-    // Also print to server console
     std::cout << "Population command executed by client " << client_fd << std::endl;
 }

--- a/src/objects/Channel.cpp
+++ b/src/objects/Channel.cpp
@@ -1,0 +1,70 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   Channel.cpp                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 10:13:38 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2025/03/19 12:18:19 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/objects/Channel.hpp"
+
+// Constructor and Destructor
+Channel::Channel() {}
+
+Channel::Channel(const std::string &name): _name(name) {}
+
+Channel::~Channel() {}
+
+// Getters and Setters
+const std::string &Channel::getName() const { return (_name);}
+const std::string &Channel::getTopic() const { return (_topic);}
+const std::vector<RegisteredClient*> &Channel::getMembers() const { return (_members);}
+const std::vector<RegisteredClient*> &Channel::getOperators() const { return (_operators);}
+
+void Channel::setTopic(const std::string &topic) { _topic = topic; }
+void Channel::setName(const std::string &name) { _name = name; }
+
+// Methods
+bool Channel::addMember(RegisteredClient *client) {
+	std::vector<RegisteredClient*>::iterator it = std::find(_members.begin(), _members.end(), client);
+	if (it == _members.end()) {
+		_members.push_back(client);
+		return (true);
+	}
+
+	return (false);
+}
+
+bool Channel::addOperator(RegisteredClient *oper) {
+	std::vector<RegisteredClient*>::iterator it = std::find(_operators.begin(), _operators.end(), oper);
+	if (it == _operators.end()) {
+		_operators.push_back(oper);
+		return (true);
+	}
+
+	return (false);
+}
+
+bool Channel::RemoveMember(RegisteredClient *client) {
+	std::vector<RegisteredClient*>::iterator it = std::find(_members.begin(), _members.end(), client);
+	if (it != _members.end()) {
+		_members.erase(it);
+		return (true);
+	}
+
+	return (false);
+}
+
+bool Channel::RemoveOperator(RegisteredClient *oper) {
+	std::vector<RegisteredClient*>::iterator it = std::find(_operators.begin(), _operators.end(), oper);
+	if (it != _operators.end()) {
+		_operators.erase(it);
+		return (true);
+	}
+
+	return (false);
+}


### PR DESCRIPTION
Developed Channel object class and Channel Manager.

We can now create and join to channels, managing operators and members.

If the channel name does not exist (join argument), it gets created. If it exists, the client joins it. If the channel was just created, the client joins as operator. Else, joins as member. 

I also implemented a "channellist/CHANNELLIST" test command to get information about available channels (name, operators, members; should also output topic when I implement "topic" command). 